### PR TITLE
native material sidenav, code improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Changed
+
+- New simplified Sidenav component
+- `Outlined` material icons font by default (see [material-icons](https://github.com/marella/material-icons))
+- Migrate AppLayout to Standalone component
+
 ## [2.0.0] - 2024-01-26
 
 ### Added
@@ -27,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to ADF `6.4.0` and JS-API `7.1.0`
 - Switch from the `Muli` font to `@fontsource/open-sans`
 - Use NPM package for the default font instead of the local copies
-- Use NPM package for the `material-icons` instead of the local copies
+- Use NPM package for the `material-icons` instead of the local copies (see [material-icons](https://github.com/marella/material-icons))
 - Move Logout to the application toolbar
 - Cleanup code and project files
 

--- a/src/app/app-layout/app-layout.component.html
+++ b/src/app/app-layout/app-layout.component.html
@@ -1,43 +1,35 @@
-<adf-sidenav-layout [sidenavMin]="70" [sidenavMax]="200" [stepOver]="780">
-  <adf-sidenav-layout-header>
-    <ng-template let-toggleMenu="toggleMenu">
-      <adf-layout-header
-        [title]="'application.name' | adfAppConfig"
-        [tooltip]="'application.name' | adfAppConfig"
-        [redirectUrl]="'/'"
-        (clicked)="toggleMenu()">
-        <div class="app-layout-menu-spacer"></div>
+<div class="page-content">
+  <mat-toolbar class="page-header">
+    <button mat-icon-button (click)="sidenav.toggle()">
+      <mat-icon>menu</mat-icon>
+    </button>
+    <div>{{ 'application.name' | adfAppConfig }}</div>
 
-        <button mat-icon-button [matMenuTriggerFor]="menu">
-          <mat-icon>more_vert</mat-icon>
-        </button>
+    <div class="app-toolbar-spacer"></div>
 
-        <mat-menu #menu="matMenu">
-          <adf-picker-button></adf-picker-button>
-          <button mat-menu-item adf-logout>
-            <mat-icon>logout</mat-icon>
-            <span>{{ 'APP.LOGOUT' | translate }}</span>
-          </button>
-        </mat-menu>
+    <button mat-icon-button [matMenuTriggerFor]="menu">
+      <mat-icon>more_vert</mat-icon>
+    </button>
 
-      </adf-layout-header>
-    </ng-template>
-  </adf-sidenav-layout-header>
+    <mat-menu #menu="matMenu">
+      <adf-picker-button></adf-picker-button>
+      <button mat-menu-item adf-logout>
+        <mat-icon>logout</mat-icon>
+        <span>{{ 'APP.LOGOUT' | translate }}</span>
+      </button>
+    </mat-menu>
+  </mat-toolbar>
 
-  <adf-sidenav-layout-navigation>
-    <ng-template let-isMenuMinimized="isMenuMinimized">
+  <mat-sidenav-container class="page-container">
+    <mat-sidenav #sidenav mode="side" opened="false" class="page-sidenav">
       <mat-nav-list>
         <a mat-list-item routerLink="/documents">
-          <mat-icon matListIcon>folder_open</mat-icon>
-          <div *ngIf="!isMenuMinimized()">{{ 'APP.NAV.DOCUMENTS' | translate }}</div>
+          <mat-icon matListIcon>text_snippet</mat-icon>
+          <div>{{ 'APP.NAV.DOCUMENTS' | translate }}</div>
         </a>
       </mat-nav-list>
-    </ng-template>
-  </adf-sidenav-layout-navigation>
+    </mat-sidenav>
 
-  <adf-sidenav-layout-content>
-    <ng-template>
-      <router-outlet></router-outlet>
-    </ng-template>
-  </adf-sidenav-layout-content>
-</adf-sidenav-layout>
+    <router-outlet></router-outlet>
+  </mat-sidenav-container>
+</div>

--- a/src/app/app-layout/app-layout.component.scss
+++ b/src/app/app-layout/app-layout.component.scss
@@ -1,7 +1,24 @@
-adf-sidenav-layout {
+.page-content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
   height: 100%;
 }
 
-.app-layout-menu-spacer {
+.page-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.page-sidenav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 200px;
+}
+
+.app-toolbar-spacer {
   flex: 1 1 auto;
 }

--- a/src/app/app-layout/app-layout.component.ts
+++ b/src/app/app-layout/app-layout.component.ts
@@ -1,7 +1,27 @@
+import { AppConfigModule, LanguageMenuModule } from '@alfresco/adf-core';
 import { Component } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
+  imports: [
+    MatToolbarModule,
+    MatIconModule,
+    MatMenuModule,
+    MatSidenavModule,
+    MatListModule,
+    RouterModule,
+    LanguageMenuModule,
+    TranslateModule,
+    AppConfigModule
+  ],
   templateUrl: './app-layout.component.html',
   styleUrls: ['./app-layout.component.scss']
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { MatIconRegistry } from '@angular/material/icon';
 import { AuthModule, CoreModule, TranslateLoaderService, provideTranslations } from '@alfresco/adf-core';
 import { ContentModule } from '@alfresco/adf-content-services';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
@@ -20,30 +21,24 @@ import localeEs from '@angular/common/locales/es';
 registerLocaleData(localeEs);
 
 @NgModule({
-    imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
-        RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledNonBlocking', relativeLinkResolution: 'legacy' }),
-        // ADF modules
-        AuthModule.forRoot({ useHash: true }),
-        CoreModule.forRoot(),
-        ContentModule.forRoot(),
-        TranslateModule.forRoot({
-            loader: { provide: TranslateLoader, useClass: TranslateLoaderService }
-        })
-    ],
-    declarations: [
-        AppComponent,
-        HomeComponent,
-        LoginComponent,
-        DocumentsComponent,
-        AppLayoutComponent,
-        FileViewComponent
-    ],
-    providers: [
-      provideTranslations('app', 'resources')
-    ],
-    bootstrap: [AppComponent]
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    RouterModule.forRoot(appRoutes),
+    AuthModule.forRoot({ useHash: true }),
+    CoreModule.forRoot(),
+    ContentModule.forRoot(),
+    TranslateModule.forRoot({
+      loader: { provide: TranslateLoader, useClass: TranslateLoaderService }
+    }),
+    AppLayoutComponent
+  ],
+  declarations: [AppComponent, HomeComponent, LoginComponent, DocumentsComponent, FileViewComponent],
+  providers: [provideTranslations('app', 'resources')],
+  bootstrap: [AppComponent]
 })
 export class AppModule {
+  constructor(matIconRegistry: MatIconRegistry) {
+    matIconRegistry.setDefaultFontSetClass('material-icons-outlined');
+  }
 }


### PR DESCRIPTION
- New simplified Sidenav component
- `Outlined` material icons font by default (see [material-icons](https://github.com/marella/material-icons))
- Migrate AppLayout to Standalone component