### PR TITLE
Configuration required for OIDC authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ BASE_URL="https://your.alfresco.backend.com" npm start
 The template provides certain proxy settings to allow running web application locally without CORS setup.
 You can find details in the `proxy.conf.js` file.
 
+#### OAuth2 configuration
+
+When you need to connect via OIDC/OAuth2, change the authorization type to OAuth `"authType": "OAUTH"` in `app.config.json` file and set the `IDENTITY_SERVICE_URL` environment variable.
+
 ## Prerequisites
 
 ### Installing Node.js and NPM

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -1,10 +1,11 @@
 const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
-
+const IDENTITY_SERVICE_URL = process.env.IDENTITY_SERVICE_URL || 'http://localhost:3000';
+console.log(IDENTITY_SERVICE_URL);
 module.exports = {
   '/alfresco': {
     target: BASE_URL,
     pathRewrite: {
-      '^/alfresco/alfresco': '',
+      '^/alfresco/alfresco': ''
     },
     secure: false,
     changeOrigin: true,
@@ -19,6 +20,12 @@ module.exports = {
       if (header?.startsWith('Basic')) {
         proxyRes.headers['www-authenticate'] = 'x' + header;
       }
-    },
+    }
   },
+  '/auth': {
+    target: IDENTITY_SERVICE_URL,
+    secure: false,
+    logLevel: 'debug',
+    changeOrigin: 'true'
+  }
 };

--- a/src/app.config.json
+++ b/src/app.config.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@alfresco/adf-core/app.config.schema.json",
   "ecmHost": "{protocol}//{hostname}{:port}",
   "providers": "ECM",
-  "authType": "BASIC",
+  "authType": "OAUTH",
   "identityHost": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",

--- a/src/app.config.json
+++ b/src/app.config.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@alfresco/adf-core/app.config.schema.json",
   "ecmHost": "{protocol}//{hostname}{:port}",
   "providers": "ECM",
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "identityHost": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",


### PR DESCRIPTION
- proxy.conf change to redirect /auth calls to identity service
- added few lines in the readme to describe the configuration needed